### PR TITLE
Adding a String constructor method for Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea
+.DS_Store

--- a/src/client.rs
+++ b/src/client.rs
@@ -126,23 +126,8 @@ impl Client {
     ///
     /// [`ClientBuilder`]: struct.ClientBuilder.html
     /// [`.stream()`]: #method.stream
-    pub fn for_url<U: r::IntoUrl>(url: U) -> Result<ClientBuilder> {
-        let url = url
-            .into_url()
-            .map_err(|e| Error::HttpRequest(Box::new(e)))?;
-        Ok(ClientBuilder {
-            url: url,
-            headers: r::header::HeaderMap::new(),
-        })
-    }
-
-    /// Construct a new `Client` (via a [`ClientBuilder`]). This will not
-    /// perform any network activity until [`.stream()`] is called.
-    ///
-    /// [`ClientBuilder`]: struct.ClientBuilder.html
-    /// [`.stream()`]: #method.stream
-    pub fn for_str(str_url: &str) -> Result<ClientBuilder> {
-        let url = Url::parse(str_url).map_err(|e| Error::HttpRequest(Box::new(e)))?;
+    pub fn for_url(url: &str) -> Result<ClientBuilder> {
+        let url = Url::parse(url).map_err(|e| Error::HttpRequest(Box::new(e)))?;
         Ok(ClientBuilder {
             url: url,
             headers: r::header::HeaderMap::new(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -142,8 +142,7 @@ impl Client {
     /// [`ClientBuilder`]: struct.ClientBuilder.html
     /// [`.stream()`]: #method.stream
     pub fn for_str(str_url: &str) -> Result<ClientBuilder> {
-        let url = Url::parse(str_url)
-            .map_err(|e| Error::HttpRequest(Box::new(e)))?;
+        let url = Url::parse(str_url).map_err(|e| Error::HttpRequest(Box::new(e)))?;
         Ok(ClientBuilder {
             url: url,
             headers: r::header::HeaderMap::new(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use std::str::from_utf8;
 use futures::future::{self, Future};
 use futures::stream::Stream;
 use reqwest as r;
-use reqwest::r#async as ra;
+use reqwest::{r#async as ra, Url};
 
 /*
  * TODO remove debug output
@@ -129,6 +129,20 @@ impl Client {
     pub fn for_url<U: r::IntoUrl>(url: U) -> Result<ClientBuilder> {
         let url = url
             .into_url()
+            .map_err(|e| Error::HttpRequest(Box::new(e)))?;
+        Ok(ClientBuilder {
+            url: url,
+            headers: r::header::HeaderMap::new(),
+        })
+    }
+
+    /// Construct a new `Client` (via a [`ClientBuilder`]). This will not
+    /// perform any network activity until [`.stream()`] is called.
+    ///
+    /// [`ClientBuilder`]: struct.ClientBuilder.html
+    /// [`.stream()`]: #method.stream
+    pub fn for_str(str_url: &str) -> Result<ClientBuilder> {
+        let url = Url::parse(str_url)
             .map_err(|e| Error::HttpRequest(Box::new(e)))?;
         Ok(ClientBuilder {
             url: url,


### PR DESCRIPTION
I didn't see a contributing doc in the repo so I am not sure the best way you want to take in contributions. I was able to work around this client side but you might want to consider trying to not leak `reqwest` internals out if you can help it.