### PR TITLE
[ch77330] review tests

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -386,6 +386,19 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
+        let mut decoded = Decoded::new(one_chunk(b"data:hello\n")
+            .chain(delay_one_then(chunk(b"data:world\n\n"))));
+
+        assert_eq!(decoded.poll(), Ok(NotReady));
+        assert_eq!(
+            decoded.poll(),
+            Ok(Ready(Some(event(
+                "",
+                &btreemap! {"data" => &b"hello\nworld"[..]}
+            ))))
+        );
+        assert_eq!(decoded.poll(), Ok(Ready(None)));
+
         let interrupted_after_event = one_chunk(b"message: hello\n\n")
             .chain(stream::poll_fn(|| Err(dummy_stream_error("read error"))));
         let mut decoded = Decoded::new(interrupted_after_event);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -365,10 +365,13 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
-        let mut decoded = Decoded::new(one_chunk(b"message:hell")
-            .chain(delay_one_then(chunk(b"o\n\nmessage:")))
-            .chain(delay_one_then(chunk(b"world\n\n"))));
+        let mut decoded = Decoded::new(
+            one_chunk(b"message:hell")
+                .chain(delay_one_then(chunk(b"o\n\nmessage:")))
+                .chain(delay_one_then(chunk(b"world\n\n"))),
+        );
 
+        assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(
             decoded.poll(),
@@ -386,8 +389,9 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
-        let mut decoded = Decoded::new(one_chunk(b"data:hello\n")
-            .chain(delay_one_then(chunk(b"data:world\n\n"))));
+        let mut decoded = Decoded::new(
+            one_chunk(b"data:hello\n").chain(delay_one_then(chunk(b"data:world\n\n"))),
+        );
 
         assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(


### PR DESCRIPTION
Added two tests that I would expect to pass. Maybe I have misunderstood how the implementation works though and this is at the wrong layer IDK.

The first test validates dispatch when messages are split at the TCP level without a newline at the end.

The second test validates (although LD does not use this feature) `data` fields being split across events in a single message.