### PR TITLE
[ch83910] Rewrite decoder to fix some decoding bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = "0.9.11"
 tokio-timer = "0.2.11"
 
 [dev-dependencies]
+env_logger = "0.7.1"
 maplit = "1.0.1"
 simplelog = "0.5.3"
 tokio = "0.1.16"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,9 @@
+# Guide to developing rust-eventsource-client
+
+Incomplete.
+
+## Get detailed logging
+
+eventsource-client uses the standard [log crate](https://crates.io/crates/log) for logging. It will log additional detail about the protocol implementation at `trace` level.
+
+e.g. if using [env_logger](https://crates.io/crates/env_logger) (as the example script does), set `RUST_LOG=eventsource_client=trace`.

--- a/examples/tail.rs
+++ b/examples/tail.rs
@@ -5,6 +5,8 @@ use futures::{future::Future, lazy, stream::Stream};
 use eventsource_client as es;
 
 fn main() -> Result<(), es::Error> {
+    env_logger::init();
+
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 3 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -149,16 +149,16 @@ where
             //  * the first line should be appended to the incomplete line, if any
 
             for line in lines {
-                trace!("decoder got a line: {:?}", logify(line));
-
                 if self.incomplete_line.is_some() {
-                    trace!(
-                        "completing line: {:?}",
-                        logify(self.incomplete_line.as_ref().unwrap())
-                    );
-
                     // only the first line can hit this case, since it clears self.incomplete_line
                     // and we don't fill it again until the end of the loop
+
+                    trace!(
+                        "completing line from previous chunk: {:?}+{:?}",
+                        logify(self.incomplete_line.as_ref().unwrap()),
+                        logify(line)
+                    );
+
                     let mut incomplete_line =
                         std::mem::replace(&mut self.incomplete_line, None).unwrap();
                     incomplete_line.extend_from_slice(line);
@@ -182,7 +182,7 @@ where
             }
 
             match maybe_incomplete_line {
-                Some(b"") => trace!("last line was empty"),
+                Some(b"") => trace!("chunk ended with a line terminator"),
                 Some(incomplete_line) => {
                     trace!("buffering incomplete line: {:?}", logify(incomplete_line));
                     self.incomplete_line = Some(incomplete_line.to_vec());
@@ -199,8 +199,6 @@ where
             let mut seen_empty_line = false;
 
             for line in complete_lines {
-                trace!("Decoder got a line: {:?}", logify(&line));
-
                 if line.is_empty() {
                     trace!("empty line");
                     seen_empty_line = true;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -137,9 +137,6 @@ where
 
             // Phase 1: decode the chunk into lines.
 
-            let mut complete_lines: Vec<Vec<u8>> = Vec::with_capacity(10);
-            let mut maybe_incomplete_line: Option<Vec<u8>> = None;
-
             // TODO also handle lines ending in \r, \r\n (and EOF?)
             let lines = chunk.split(|&b| b == b'\n');
             // The first and last elements in this split are special. The spec requires lines to be
@@ -147,6 +144,9 @@ where
             //  * the last line, if non-empty (i.e. if chunk didn't end with a line terminator),
             //    should be buffered as an incomplete line
             //  * the first line should be appended to the incomplete line, if any
+
+            let mut complete_lines: Vec<Vec<u8>> = Vec::with_capacity(10);
+            let mut maybe_incomplete_line: Option<Vec<u8>> = None;
 
             for line in lines {
                 if let Some(incomplete_line) = &mut self.incomplete_line {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -147,7 +147,7 @@ where
 
             // Phase 1: decode the chunk into lines.
 
-            // TODO also handle lines ending in \r, \r\n (and EOF?)
+            // TODO(ch86257) also handle lines ending in \r, \r\n (and EOF?)
             let lines = chunk.split(|&b| b == b'\n');
             // The first and last elements in this split are special. The spec requires lines to be
             // terminated. But lines may span chunks, so:

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -386,6 +386,19 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
+        let mut decoded = Decoded::new(one_chunk(b"data:hello\n")
+            .chain(delay_one_then(chunk(b"data:world\n\n"))));
+
+        assert_eq!(decoded.poll(), Ok(NotReady));
+        assert_eq!(
+            decoded.poll(),
+            Ok(Ready(Some(event(
+                "",
+                &btreemap! {"data" => &b"hello\nworld"[..]}
+            ))))
+        );
+        assert_eq!(decoded.poll(), Ok(Ready(None)));
+
         let interrupted_after_event = one_chunk(b"message: hello\n\n")
             .chain(stream::poll_fn(|| Err(dummy_stream_error("read error"))));
         let mut decoded = Decoded::new(interrupted_after_event);

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -365,10 +365,13 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
-        let mut decoded = Decoded::new(one_chunk(b"message:hell")
-            .chain(delay_one_then(chunk(b"o\n\nmessage:")))
-            .chain(delay_one_then(chunk(b"world\n\n"))));
+        let mut decoded = Decoded::new(
+            one_chunk(b"message:hell")
+                .chain(delay_one_then(chunk(b"o\n\nmessage:")))
+                .chain(delay_one_then(chunk(b"world\n\n"))),
+        );
 
+        assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(
             decoded.poll(),
@@ -386,8 +389,9 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
-        let mut decoded = Decoded::new(one_chunk(b"data:hello\n")
-            .chain(delay_one_then(chunk(b"data:world\n\n"))));
+        let mut decoded = Decoded::new(
+            one_chunk(b"data:hello\n").chain(delay_one_then(chunk(b"data:world\n\n"))),
+        );
 
         assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -411,13 +411,8 @@ mod tests {
         );
         assert_eq!(decoded.poll(), Ok(Ready(None)));
 
-        let mut decoded = Decoded::new(
-            one_chunk(b"message:hell")
-                .chain(delay_one_then(chunk(b"o\n\nmessage:")))
-                .chain(delay_one_then(chunk(b"world\n\n"))),
-        );
-
-        assert_eq!(decoded.poll(), Ok(NotReady));
+        let mut decoded =
+            Decoded::new(one_chunk(b"message:hell").chain(delay_one_then(chunk(b"o\n\n"))));
         assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(
             decoded.poll(),
@@ -426,6 +421,23 @@ mod tests {
                 &btreemap! {"message" => &b"hello"[..]}
             ))))
         );
+        assert_eq!(decoded.poll(), Ok(Ready(None)));
+
+        let mut decoded = Decoded::new(
+            one_chunk(b"message:hell")
+                .chain(delay_one_then(chunk(b"o\n\nmessage:")))
+                .chain(delay_one_then(chunk(b"world\n\n"))),
+        );
+
+        assert_eq!(decoded.poll(), Ok(NotReady));
+        assert_eq!(
+            decoded.poll(),
+            Ok(Ready(Some(event(
+                "",
+                &btreemap! {"message" => &b"hello"[..]}
+            ))))
+        );
+        assert_eq!(decoded.poll(), Ok(NotReady));
         assert_eq!(
             decoded.poll(),
             Ok(Ready(Some(event(

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -141,7 +141,7 @@ where
             let mut maybe_incomplete_line: Option<&[u8]> = None;
 
             // TODO also handle lines ending in \r, \r\n (and EOF?)
-            let mut lines = chunk.split(|&b| b == b'\n');
+            let lines = chunk.split(|&b| b == b'\n');
             // The first and last elements in this split are special. The spec requires lines to be
             // terminated. But lines may span chunks, so:
             //  * the last line, if non-empty (i.e. if chunk didn't end with a line terminator),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,3 @@ pub use client::*;
 pub use config::*;
 pub use decode::{Event, EventStream};
 pub use error::*;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
This fixes a few bugs and places we weren't quite compliant with the spec:
 * the handling for lines split across chunks wasn't quite right and could drop lines if that happened more than once in a stream.
 * we were stripping all leading spaces from field values, instead of just the first leading space.
 * multiple values for the same field would overwrite (now they concatenate instead)
 * a line without a colon was treated as an error (now it treats the whole line as the field name, with an empty field value)

Closes #2 (includes commits from that PR, which included tests that discovered some of these bugs).