### PR TITLE
Allow specifying HTTP client directly

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -79,6 +79,17 @@ impl ClientBuilder {
         let conn = HttpsConnector::with_native_roots();
         self.build_with_conn(conn)
     }
+
+    pub fn build_with_http<C>(self, http: hyper::Client<C>) -> Client<C> {
+        Client {
+            http,
+            request_props: RequestProps {
+                url: self.url,
+                headers: self.headers,
+                reconnect_opts: self.reconnect_opts,
+            },
+        }
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
The `hyper` client builder allows specifying many useful options, notably `pool_idle_timeout` and `http2_keep_alive_interval`, which are super useful to make sure persistent connections stay alive. 

This PR extends the `rust-eventsource-client` builder with the ability to pass the `hyper` client directly, which allows for maximal flexibility. 
