### PR TITLE
Handle '\r\n' line endings in stream data

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -206,7 +206,12 @@ impl<S: Stream> Decoded<S> {
         }
 
         let mut lines = lines.peekable();
-        while let Some(line) = lines.next() {
+        while let Some(mut line) = lines.next() {
+            // handle `\r\n` line ending as an acceptable line break
+            // to address part of the above TODO
+            if line.ends_with(&[b'\r']) {
+                line = &line[..line.len() - 1];
+            }
             if let Some(actually_complete_line) = this.incomplete_line.take() {
                 // we saw the next line, so the previous one must have been complete after all
                 trace!(


### PR DESCRIPTION
Needed to make this change to use this code when a SSE server sent line endings encoded as `\r\n` instead of simply `\n`.

Rather than modifying how the initial code parses line breaks, this code just chops off any trailing `\r` with the intention being to capture `\r\n` across both places in the code base. 

However, ideally the line parse is re-written to handle any of the possible "newline" values. If you would rather prefer a more maintainable/extensible implementation, feel free to close this one. Opening the PR mainly to serve as a reference/info for others and in the event you do want to incorporate these changes upstream.

Cheers!