### PR TITLE
Refactor Client to a trait

### DIFF
--- a/contract-tests/Cargo.toml
+++ b/contract-tests/Cargo.toml
@@ -13,7 +13,7 @@ actix = { version = "0.12.0"}
 actix-web = { version = "4.0.0-beta.10"}
 reqwest = { version = "0.11.6", default_features = false, features = ["json", "rustls-tls"] }
 env_logger = { version = "0.7.1" }
-hyper = { version = "0.14.4", features = ["client", "http1", "tcp"] }
+hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
 log = "0.4.6"
 
 [[bin]]

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -87,7 +87,7 @@ impl Inner {
     }
 
     fn build_client(config: &Config) -> Result<Box<dyn es::Client>, String> {
-        let mut client_builder = match es::for_url(&config.stream_url) {
+        let mut client_builder = match es::ClientBuilder::for_url(&config.stream_url) {
             Ok(cb) => cb,
             Err(e) => return Err(format!("Failed to create client builder {:?}", e)),
         };

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -11,8 +11,6 @@ use eventsource_client as es;
 
 use crate::{Config, EventType};
 
-type Connector = es::HttpsConnector;
-
 pub(crate) struct Inner {
     callback_counter: Mutex<i32>,
     callback_url: String,

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -108,7 +108,9 @@ impl Inner {
             }
         }
 
-        Ok(client_builder.reconnect(reconnect_options.build()).build())
+        Ok(Box::pin(
+            client_builder.reconnect(reconnect_options.build()).build(),
+        ))
     }
 }
 

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -1,7 +1,6 @@
 use actix_web::rt::task::JoinHandle;
 use futures::TryStreamExt;
 use log::error;
-use std::pin::Pin;
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
@@ -14,7 +13,7 @@ use crate::{Config, EventType};
 pub(crate) struct Inner {
     callback_counter: Mutex<i32>,
     callback_url: String,
-    client: Pin<Box<dyn es::Client>>,
+    client: Box<dyn es::Client>,
 }
 
 impl Inner {
@@ -87,7 +86,7 @@ impl Inner {
         true
     }
 
-    fn build_client(config: &Config) -> Result<Pin<Box<dyn es::Client>>, String> {
+    fn build_client(config: &Config) -> Result<Box<dyn es::Client>, String> {
         let mut client_builder = match es::for_url(&config.stream_url) {
             Ok(cb) => cb,
             Err(e) => return Err(format!("Failed to create client builder {:?}", e)),
@@ -108,7 +107,7 @@ impl Inner {
             }
         }
 
-        Ok(Box::pin(
+        Ok(Box::new(
             client_builder.reconnect(reconnect_options.build()).build(),
         ))
     }

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -1,6 +1,7 @@
 use actix_web::rt::task::JoinHandle;
 use futures::TryStreamExt;
 use log::error;
+use std::pin::Pin;
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
@@ -15,7 +16,7 @@ type Connector = es::HttpsConnector;
 pub(crate) struct Inner {
     callback_counter: Mutex<i32>,
     callback_url: String,
-    client: Box<dyn es::Client>,
+    client: Pin<Box<dyn es::Client>>,
 }
 
 impl Inner {
@@ -88,7 +89,7 @@ impl Inner {
         true
     }
 
-    fn build_client(config: &Config) -> Result<Box<dyn es::Client>, String> {
+    fn build_client(config: &Config) -> Result<Pin<Box<dyn es::Client>>, String> {
         let mut client_builder = match es::for_url(&config.stream_url) {
             Ok(cb) => cb,
             Err(e) => return Err(format!("Failed to create client builder {:?}", e)),

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -1,12 +1,14 @@
 use actix_web::rt::task::JoinHandle;
-use futures::TryStreamExt;
+use futures::{Stream, StreamExt, TryStream, TryStreamExt};
 use log::error;
 use std::{
+    pin,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use eventsource_client as es;
+use std::pin::Pin;
 
 use crate::{Config, EventType};
 
@@ -15,7 +17,7 @@ type Connector = es::HttpsConnector;
 pub(crate) struct Inner {
     callback_counter: Mutex<i32>,
     callback_url: String,
-    client: es::Client<Connector>,
+    client: Box<dyn es::Client>,
 }
 
 impl Inner {
@@ -30,9 +32,8 @@ impl Inner {
     }
 
     pub(crate) async fn start(&self) {
-        let stream = self.client.stream();
+        let mut stream = self.client.stream();
 
-        let mut stream = Box::pin(stream);
         let client = reqwest::Client::new();
 
         loop {
@@ -89,8 +90,8 @@ impl Inner {
         true
     }
 
-    fn build_client(config: &Config) -> Result<es::Client<Connector>, String> {
-        let mut client_builder = match es::Client::for_url(&config.stream_url) {
+    fn build_client(config: &Config) -> Result<Box<dyn es::Client>, String> {
+        let mut client_builder = match es::for_url(&config.stream_url) {
             Ok(cb) => cb,
             Err(e) => return Err(format!("Failed to create client builder {:?}", e)),
         };

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -1,14 +1,12 @@
 use actix_web::rt::task::JoinHandle;
-use futures::{Stream, StreamExt, TryStream, TryStreamExt};
+use futures::TryStreamExt;
 use log::error;
 use std::{
-    pin,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use eventsource_client as es;
-use std::pin::Pin;
 
 use crate::{Config, EventType};
 

--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -13,12 +13,12 @@ exclude = [
 ]
 
 [dependencies]
-futures = "0.3.12"
-hyper = { version = "0.14.4", features = ["client", "http1", "tcp"] }
+futures = "0.3.21"
+hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
 hyper-rustls = { version = "0.22.1", optional = true }
 log = "0.4.6"
-pin-project = "1.0.5"
-tokio = { version = "1.2.0", features = ["time"] }
+pin-project = "1.0.10"
+tokio = { version = "1.17.0", features = ["time"] }
 hyper-timeout = "0.4.1"
 
 [dev-dependencies]

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -1,8 +1,10 @@
 use std::{env, process, str::from_utf8, time::Duration};
 
+use futures::stream::{MapErr, MapOk};
 use futures::{Stream, TryStreamExt};
 
 use eventsource_client as es;
+use eventsource_client::BoxStream;
 
 #[tokio::main]
 async fn main() -> Result<(), es::Error> {
@@ -18,7 +20,7 @@ async fn main() -> Result<(), es::Error> {
     let url = &args[1];
     let auth_header = &args[2];
 
-    let client = es::Client::for_url(url)?
+    let client = es::for_url(url)?
         .header("Authorization", auth_header)?
         .reconnect(
             es::ReconnectOptions::reconnect(true)
@@ -30,14 +32,7 @@ async fn main() -> Result<(), es::Error> {
         )
         .build();
 
-    let mut stream = Box::pin(tail_events(client));
-    while let Ok(Some(_)) = stream.try_next().await {}
-
-    Ok(())
-}
-
-fn tail_events(client: es::Client<es::HttpsConnector>) -> impl Stream<Item = Result<(), ()>> {
-    client
+    let mut stream = client
         .stream()
         .map_ok(|event| {
             println!(
@@ -46,5 +41,25 @@ fn tail_events(client: es::Client<es::HttpsConnector>) -> impl Stream<Item = Res
                 from_utf8(event.field("data").unwrap_or_default()).unwrap_or_default()
             )
         })
-        .map_err(|err| eprintln!("error streaming events: {:?}", err))
+        .map_err(|err| eprintln!("error streaming events: {:?}", err));
+
+    while let Ok(Some(_)) = stream.try_next().await {}
+
+    Ok(())
 }
+
+// fn tail_events(
+//     stream: &BoxStream<es::Result<es::Event>>,
+// ) -> impl Stream<Item = Result<es::Event, es::Error>> {
+//     stream.map_ok(|event| println!("hi"))
+//     // client
+//     //     .stream()
+//     //     .map_ok(|event| {
+//     //         println!(
+//     //             "got an event: {}\n{}",
+//     //             event.event_type,
+//     //             from_utf8(event.field("data").unwrap_or_default()).unwrap_or_default()
+//     //         )
+//     //     })
+//     //     .map_err(|err| eprintln!("error streaming events: {:?}", err))
+// }

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -1,8 +1,9 @@
-use es::{BoxStream, Event};
+use es::{BoxStream, Client, Event};
 use futures::{Stream, TryStreamExt};
 use std::{env, process, str::from_utf8, time::Duration};
 
 use eventsource_client as es;
+use eventsource_client::HttpsConnector;
 
 #[tokio::main]
 async fn main() -> Result<(), es::Error> {

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -3,7 +3,6 @@ use futures::{Stream, TryStreamExt};
 use std::{env, process, str::from_utf8, time::Duration};
 
 use eventsource_client as es;
-use eventsource_client::HttpsConnector;
 
 #[tokio::main]
 async fn main() -> Result<(), es::Error> {

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), es::Error> {
     let url = &args[1];
     let auth_header = &args[2];
 
-    let client = es::for_url(url)?
+    let client = es::ClientBuilder::for_url(url)?
         .header("Authorization", auth_header)?
         .reconnect(
             es::ReconnectOptions::reconnect(true)

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -1,10 +1,8 @@
 use std::{env, process, str::from_utf8, time::Duration};
 
-use futures::stream::{MapErr, MapOk};
-use futures::{Stream, TryStreamExt};
+use futures::TryStreamExt;
 
 use eventsource_client as es;
-use eventsource_client::BoxStream;
 
 #[tokio::main]
 async fn main() -> Result<(), es::Error> {

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), es::Error> {
     Ok(())
 }
 
-fn tail_events(stream: BoxStream<es::Result<Event>>) -> impl Stream<Item = Result<(), ()>> + '_ {
+fn tail_events(stream: BoxStream<es::Result<Event>>) -> impl Stream<Item = Result<(), ()>> {
     stream
         .map_ok(|event| {
             println!(

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -30,7 +30,6 @@ async fn main() -> Result<(), es::Error> {
         )
         .build();
 
-    let stream = client.stream();
     let mut stream = tail_events(client.stream());
 
     while let Ok(Some(_)) = stream.try_next().await {}

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -1,4 +1,4 @@
-use es::{BoxStream, Client, Event};
+use es::Client;
 use futures::{Stream, TryStreamExt};
 use std::{env, process, str::from_utf8, time::Duration};
 
@@ -30,15 +30,16 @@ async fn main() -> Result<(), es::Error> {
         )
         .build();
 
-    let mut stream = tail_events(client.stream());
+    let mut stream = tail_events(client);
 
     while let Ok(Some(_)) = stream.try_next().await {}
 
     Ok(())
 }
 
-fn tail_events(stream: BoxStream<es::Result<Event>>) -> impl Stream<Item = Result<(), ()>> {
-    stream
+fn tail_events(client: impl Client) -> impl Stream<Item = Result<(), ()>> {
+    client
+        .stream()
         .map_ok(|event| {
             println!(
                 "got an event: {}\n{}",

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -3,7 +3,6 @@ use hyper::{
     body::{Bytes, HttpBody},
     client::{connect::Connect, ResponseFuture},
     header::{HeaderMap, HeaderName, HeaderValue},
-    service::Service,
     Body, Request, StatusCode, Uri,
 };
 #[cfg(feature = "rustls")]
@@ -69,7 +68,7 @@ impl ClientBuilder {
 
     pub fn build_with_conn<C>(self, conn: C) -> Pin<Box<dyn Client>>
     where
-        C: Service<Uri> + Connect + Clone + Send + Sync + 'static,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         Box::pin(ClientImpl {
             http: hyper::Client::builder().build(conn),
@@ -93,7 +92,7 @@ impl ClientBuilder {
 
     pub fn build_with_http_client<C>(self, http: hyper::Client<C>) -> Pin<Box<dyn Client>>
     where
-        C: Service<Uri> + Connect + Clone + Send + Sync + 'static,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         Box::pin(ClientImpl {
             http,
@@ -139,7 +138,7 @@ pub type EventStream<C> = Decoded<ReconnectingRequest<C>>;
 
 impl<C> Client for ClientImpl<C>
 where
-    C: Service<Uri> + Connect + Clone + Send + Sync + 'static,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     /// Connect to the server and begin consuming the stream. Produces a
     /// [`Stream`] of [`Event`](crate::Event)s wrapped in [`Result`].
@@ -240,7 +239,7 @@ impl<C> ReconnectingRequest<C> {
 
 impl<C> Stream for ReconnectingRequest<C>
 where
-    C: Service<Uri> + Connect + Clone + Send + Sync + 'static,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     type Item = Result<Bytes>;
 

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -33,7 +33,7 @@ pub type HttpsConnector = RustlsConnector<HttpConnector>;
 
 /* Copied from futures::stream::BoxStream, but modified to require additional Sync bound
 so it can be shared between threads. */
-pub type BoxStream<'a, T> = Pin<boxed::Box<dyn Stream<Item = T> + Send + Sync + 'a>>;
+pub type BoxStream<T> = Pin<boxed::Box<dyn Stream<Item = T> + Send + Sync>>;
 
 /// This trait is sealed and cannot be implemented for types outside this crate.
 pub trait Client: Send + Sync + private::Sealed {

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -73,42 +73,42 @@ impl ClientBuilder {
         self
     }
 
-    pub fn build_with_conn<C>(self, conn: C) -> Pin<Box<dyn Client>>
+    pub fn build_with_conn<C>(self, conn: C) -> impl Client
     where
         C: Connect + Clone + Send + Sync + 'static,
     {
-        Box::pin(ClientImpl {
+        ClientImpl {
             http: hyper::Client::builder().build(conn),
             request_props: RequestProps {
                 url: self.url,
                 headers: self.headers,
                 reconnect_opts: self.reconnect_opts,
             },
-        })
+        }
     }
 
-    pub fn build_http(self) -> Pin<Box<dyn Client>> {
+    pub fn build_http(self) -> impl Client {
         self.build_with_conn(HttpConnector::new())
     }
 
     #[cfg(feature = "rustls")]
-    pub fn build(self) -> Pin<Box<dyn Client>> {
+    pub fn build(self) -> impl Client {
         let conn = HttpsConnector::with_native_roots();
         self.build_with_conn(conn)
     }
 
-    pub fn build_with_http_client<C>(self, http: hyper::Client<C>) -> Pin<Box<dyn Client>>
+    pub fn build_with_http_client<C>(self, http: hyper::Client<C>) -> impl Client
     where
         C: Connect + Clone + Send + Sync + 'static,
     {
-        Box::pin(ClientImpl {
+        ClientImpl {
             http,
             request_props: RequestProps {
                 url: self.url,
                 headers: self.headers,
                 reconnect_opts: self.reconnect_opts,
             },
-        })
+        }
     }
 }
 

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -52,6 +52,18 @@ pub struct ClientBuilder {
 }
 
 impl ClientBuilder {
+    /// Create a builder for a given URL.
+    pub fn for_url(url: &str) -> Result<ClientBuilder> {
+        let url = url
+            .parse()
+            .map_err(|e| Error::InvalidParameter(Box::new(e)))?;
+        Ok(ClientBuilder {
+            url,
+            headers: HeaderMap::new(),
+            reconnect_opts: ReconnectOptions::default(),
+        })
+    }
+
     /// Set a HTTP header on the SSE request.
     pub fn header(mut self, name: &str, value: &str) -> Result<ClientBuilder> {
         let name =
@@ -125,17 +137,6 @@ struct RequestProps {
 struct ClientImpl<C> {
     http: hyper::Client<C>,
     request_props: RequestProps,
-}
-
-pub fn for_url(url: &str) -> Result<ClientBuilder> {
-    let url = url
-        .parse()
-        .map_err(|e| Error::InvalidParameter(Box::new(e)))?;
-    Ok(ClientBuilder {
-        url,
-        headers: HeaderMap::new(),
-        reconnect_opts: ReconnectOptions::default(),
-    })
 }
 
 impl<C> Client for ClientImpl<C>

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -1,5 +1,4 @@
-use futures::stream::BoxStream as FuturesBoxStream;
-use futures::{ready, Stream, StreamExt, TryStream, TryStreamExt};
+use futures::{ready, Stream};
 use hyper::{
     body::{Bytes, HttpBody},
     client::{connect::Connect, ResponseFuture},
@@ -149,15 +148,10 @@ where
     /// After the first successful connection, the stream will
     /// reconnect for retryable errors.
     fn stream(&self) -> BoxStream<Result<Event>> {
-        let r = ReconnectingRequest::new(self.http.clone(), self.request_props.clone());
-        let d = Decoded::new(r);
-        Box::pin(d)
-        // FuturesBoxStream::new(d)
-        // FuturesBoxStream::new(Decoded::new(ReconnectingRequest::new(
-        //     self.http.clone(),
-        //     self.request_props.clone(),
-        // )))
-        // todo!()
+        Box::pin(Decoded::new(ReconnectingRequest::new(
+            self.http.clone(),
+            self.request_props.clone(),
+        )))
     }
 }
 

--- a/eventsource-client/src/decode.rs
+++ b/eventsource-client/src/decode.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::{
     ready,
     stream::{Fuse, Stream},
-    StreamExt,
+    StreamExt, TryStream, TryStreamExt,
 };
 use hyper::body::Bytes;
 use log::{debug, log_enabled, trace};

--- a/eventsource-client/src/decode.rs
+++ b/eventsource-client/src/decode.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::{
     ready,
     stream::{Fuse, Stream},
-    StreamExt, TryStream, TryStreamExt,
+    StreamExt,
 };
 use hyper::body::Bytes;
 use log::{debug, log_enabled, trace};

--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -1,16 +1,16 @@
 //! Client for the [Server-Sent Events] protocol (aka [EventSource]).
 //!
 //! ```
-//! use eventsource_client as es;
+//! use eventsource_client::Client;
 //! # use futures::{Stream, TryStreamExt};
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), eventsource_client::Error> {
-//! let mut client = es::for_url("https://example.com/stream")?
+//! let mut client = eventsource_client::for_url("https://example.com/stream")?
 //!     .header("Authorization", "Basic username:password")?
 //!     .build();
 //!
-//! let mut stream = client.stream()
+//! let mut stream = Box::pin(client.stream())
 //!     .map_ok(|event| println!("got an event: {}", event.event_type))
 //!     .map_err(|e| println!("error streaming events: {:?}", e));
 //! # while let Ok(Some(_)) = stream.try_next().await {}

--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -1,12 +1,12 @@
 //! Client for the [Server-Sent Events] protocol (aka [EventSource]).
 //!
 //! ```
-//! use eventsource_client::Client;
-//! # use futures::{Stream, TryStreamExt};
-//!
+//! use futures::{Stream, TryStreamExt};
+//! use eventsource_client as es;
+//! use es::{Client, Error};
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), eventsource_client::Error> {
-//! let mut client = eventsource_client::for_url("https://example.com/stream")?
+//! # async fn main() -> Result<(), Error> {
+//! let mut client = es::ClientBuilder::for_url("https://example.com/stream")?
 //!     .header("Authorization", "Basic username:password")?
 //!     .build();
 //!

--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -1,12 +1,12 @@
 //! Client for the [Server-Sent Events] protocol (aka [EventSource]).
 //!
 //! ```
-//! use futures::{Stream, TryStreamExt};
-//! use eventsource_client as es;
-//! use es::{Client, Error};
+//! use futures::{TryStreamExt};
+//! # use eventsource_client::Error;
+//! use eventsource_client::Client;
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Error> {
-//! let mut client = es::ClientBuilder::for_url("https://example.com/stream")?
+//! # async fn main() -> Result<(), eventsource_client::Error> {
+//! let mut client = eventsource_client::ClientBuilder::for_url("https://example.com/stream")?
 //!     .header("Authorization", "Basic username:password")?
 //!     .build();
 //!

--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -1,16 +1,16 @@
 //! Client for the [Server-Sent Events] protocol (aka [EventSource]).
 //!
 //! ```
-//! use eventsource_client::Client;
+//! use eventsource_client as es;
 //! # use futures::{Stream, TryStreamExt};
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), eventsource_client::Error> {
-//! let mut client = Client::for_url("https://example.com/stream")?
+//! let mut client = es::for_url("https://example.com/stream")?
 //!     .header("Authorization", "Basic username:password")?
 //!     .build();
 //!
-//! let mut stream = Box::pin(client.stream())
+//! let mut stream = client.stream()
 //!     .map_ok(|event| println!("got an event: {}", event.event_type))
 //!     .map_err(|e| println!("error streaming events: {:?}", e));
 //! # while let Ok(Some(_)) = stream.try_next().await {}


### PR DESCRIPTION
This draft hides the event source client's implementation (previously known as `Client`, now `ClientImpl`) behind a trait (known as `Client`).

This trait exposes only a `stream()` method, which is what `Client` exposed before.

My goal is to be able to add new functionality to Client without breaking changes for downstream users. 

The immediate need is for us to wrap whatever connector the user gives us in a `TimeoutConnector`, which allows us fine-grained control over read timeouts.

Previously, this would have been a breaking change, since the Client you get back from the builder would then be a `Client<TimeoutConnector<....>>`. 

I'm not sure that I've done this idiomatically, so please let me know if there are better ways to accomplish my goal.
Another way to do this would be to hide only the `hyper::Client` behind a trait, and keep exposing a concrete Client struct.

I've also upgraded hyper, tokio, futures, and pin-project to the latest versions.
