### PR TITLE
Allow SSE tests to use new config options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TEMP_TEST_OUTPUT=/tmp/contract-test-service.log
-SKIPFLAGS = -skip 'basic parsing' -skip 'HTTP behavior' -skip 'reconnection'
+SKIPFLAGS = -skip 'reconnection' -skip 'basic parsing/ID field is ignored if it contains a null' -skip 'basic parsing/last ID persists if not overridden by later event' \
+-skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
+
 
 build-contract-tests:
 	@cargo build

--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -32,6 +32,19 @@ struct Config {
     /// property if the test service has the "headers" capability. Header names can be assumed
     /// to all be lowercase.
     headers: Option<HashMap<String, String>>,
+    /// An optional integer specifying the read timeout for the connection, in
+    /// milliseconds.
+    read_timeout_ms: Option<u64>,
+    /// An optional string which should be sent as the Last-Event-Id header in the initial
+    /// HTTP request. The test harness will only set this property if the test service has the
+    /// "last-event-id" capability.
+    last_event_id: Option<String>,
+    /// A string specifying an HTTP method to use instead of GET. The test harness will only
+    /// set this property if the test service has the "post" or "report" capability.
+    method: Option<String>,
+    /// A string specifying data to be sent in the HTTP request body. The test harness will
+    /// only set this property if the test service has the "post" or "report" capability.
+    body: Option<String>,
 }
 
 #[derive(Serialize, Debug)]

--- a/contract-tests/src/bin/sse-test-api/stream_entity.rs
+++ b/contract-tests/src/bin/sse-test-api/stream_entity.rs
@@ -98,6 +98,22 @@ impl Inner {
             reconnect_options = reconnect_options.delay(Duration::from_millis(delay_ms));
         }
 
+        if let Some(read_timeout_ms) = config.read_timeout_ms {
+            client_builder = client_builder.read_timeout(Duration::from_millis(read_timeout_ms));
+        }
+
+        if let Some(last_event_id) = &config.last_event_id {
+            client_builder = client_builder.last_event_id(last_event_id.clone());
+        }
+
+        if let Some(method) = &config.method {
+            client_builder = client_builder.method(method.to_string());
+        }
+
+        if let Some(body) = &config.body {
+            client_builder = client_builder.body(body.to_string());
+        }
+
         if let Some(headers) = &config.headers {
             for (name, value) in headers {
                 client_builder = match client_builder.header(name, value) {


### PR DESCRIPTION
Allows the test harness to use the new builder options exposed by the eventsource `ClientBuilder`.

With this PR, we are able to remove a bunch of broad test skipping in favor of more fine-grained skips.