### PR TITLE
Ignore invalid event IDs & persist existing event IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 TEMP_TEST_OUTPUT=/tmp/contract-test-service.log
-SKIPFLAGS = -skip 'reconnection' -skip 'basic parsing/ID field is ignored if it contains a null' -skip 'basic parsing/last ID persists if not overridden by later event' \
--skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
+SKIPFLAGS = -skip 'reconnection' -skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
 
 
 build-contract-tests:

--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -61,13 +61,11 @@ impl From<es::SSE> for EventType {
             es::SSE::Event(evt) => Self::Event {
                 event: Event {
                     event_type: evt.event_type,
-                    data: String::from_utf8(evt.data.to_vec()).unwrap(),
-                    id: evt.id.map(|id| String::from_utf8(id).unwrap()),
+                    data: evt.data,
+                    id: evt.id,
                 },
             },
-            es::SSE::Comment(comment) => Self::Comment {
-                comment: String::from_utf8(comment).unwrap(),
-            },
+            es::SSE::Comment(comment) => Self::Comment { comment },
         }
     }
 }

--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -62,7 +62,7 @@ impl From<es::SSE> for EventType {
                 event: Event {
                     event_type: evt.event_type,
                     data: String::from_utf8(evt.data.to_vec()).unwrap(),
-                    id: String::from_utf8(evt.id.to_vec()).unwrap(),
+                    id: evt.id.map(|id| String::from_utf8(id).unwrap()),
                 },
             },
             es::SSE::Comment(comment) => Self::Comment {
@@ -77,7 +77,7 @@ struct Event {
     #[serde(rename = "type")]
     event_type: String,
     data: String,
-    id: String,
+    id: Option<String>,
 }
 
 async fn status() -> impl Responder {

--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -84,8 +84,8 @@ async fn status() -> impl Responder {
             // "comments".to_string(),
             // "post".to_string(),
             // "report".to_string(),
-            // "headers".to_string(),
-            // "last-event-id".to_string(),
+            "headers".to_string(),
+            "last-event-id".to_string(),
         ],
     })
 }

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -1,6 +1,6 @@
 use es::Client;
 use futures::{Stream, TryStreamExt};
-use std::{env, process, str::from_utf8, time::Duration};
+use std::{env, process, time::Duration};
 
 use eventsource_client as es;
 
@@ -42,17 +42,10 @@ fn tail_events(client: impl Client) -> impl Stream<Item = Result<(), ()>> {
         .stream()
         .map_ok(|event| match event {
             es::SSE::Event(ev) => {
-                println!(
-                    "got an event: {}\n{}",
-                    ev.event_type,
-                    from_utf8(&ev.data).unwrap_or_default()
-                )
+                println!("got an event: {}\n{}", ev.event_type, ev.data)
             }
             es::SSE::Comment(comment) => {
-                println!(
-                    "got a comment: \n{}",
-                    from_utf8(&comment).unwrap_or_default()
-                )
+                println!("got a comment: \n{}", comment)
             }
         })
         .map_err(|err| eprintln!("error streaming events: {:?}", err))

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -358,8 +358,7 @@ where
                 return match event {
                     SSE::Event(ref evt) => {
                         if evt.id.is_some() {
-                            *this.last_event_id =
-                                String::from_utf8(evt.id.as_ref().unwrap().clone()).ok();
+                            *this.last_event_id = evt.id.clone();
                         }
 
                         if let Some(retry) = evt.retry {

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -65,7 +65,7 @@ pub struct ClientBuilder {
     headers: HeaderMap,
     reconnect_opts: ReconnectOptions,
     read_timeout: Option<Duration>,
-    last_event_id: String,
+    last_event_id: Option<String>,
     method: String,
     body: Option<String>,
 }
@@ -86,7 +86,7 @@ impl ClientBuilder {
             headers: header_map,
             reconnect_opts: ReconnectOptions::default(),
             read_timeout: None,
-            last_event_id: String::new(),
+            last_event_id: None,
             method: String::from("GET"),
             body: None,
         })
@@ -107,7 +107,7 @@ impl ClientBuilder {
     /// Set the last event id for a stream when it is created. If it is set, it will be sent to the
     /// server in case it can replay missed events.
     pub fn last_event_id(mut self, last_event_id: String) -> ClientBuilder {
-        self.last_event_id = last_event_id;
+        self.last_event_id = Some(last_event_id);
         self
     }
 
@@ -209,7 +209,7 @@ struct RequestProps {
 struct ClientImpl<C> {
     http: hyper::Client<C>,
     request_props: RequestProps,
-    last_event_id: String,
+    last_event_id: Option<String>,
 }
 
 impl<C> Client for ClientImpl<C>
@@ -274,14 +274,14 @@ pub struct ReconnectingRequest<C> {
     state: State,
     next_reconnect_delay: Duration,
     event_parser: EventParser,
-    last_event_id: String,
+    last_event_id: Option<String>,
 }
 
 impl<C> ReconnectingRequest<C> {
     fn new(
         http: hyper::Client<C>,
         props: RequestProps,
-        last_event_id: String,
+        last_event_id: Option<String>,
     ) -> ReconnectingRequest<C> {
         let reconnect_delay = props.reconnect_opts.delay;
         ReconnectingRequest {
@@ -306,11 +306,11 @@ impl<C> ReconnectingRequest<C> {
             request_builder = request_builder.header(name, value);
         }
 
-        if !self.last_event_id.is_empty() {
-            request_builder = request_builder.header(
-                "last-event-id",
-                HeaderValue::from_str(&self.last_event_id.clone()).unwrap(),
-            );
+        if self.last_event_id.is_some() {
+            let id_as_header = HeaderValue::from_str(self.last_event_id.as_ref().unwrap())
+                .map_err(|e| Error::InvalidParameter(Box::new(e)))?;
+
+            request_builder = request_builder.header("last-event-id", id_as_header);
         }
 
         let body = match &self.props.body {
@@ -357,8 +357,9 @@ where
             if let Some(event) = this.event_parser.get_event() {
                 return match event {
                     SSE::Event(ref evt) => {
-                        if !evt.id.is_empty() {
-                            *this.last_event_id = String::from_utf8(evt.id.clone()).unwrap();
+                        if evt.id.is_some() {
+                            *this.last_event_id =
+                                String::from_utf8(evt.id.as_ref().unwrap().clone()).ok();
                         }
 
                         if let Some(retry) = evt.retry {

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -18,8 +18,6 @@ pub enum Error {
     UnexpectedEof,
     /// Encountered a line not conforming to the SSE protocol.
     InvalidLine(String),
-    /// Encountered an event type that is not a valid UTF-8 byte sequence.
-    InvalidEventType(std::str::Utf8Error),
     InvalidEvent,
     /// An unexpected failure occurred.
     Unexpected(Box<dyn std::error::Error + Send + 'static>),

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -53,19 +53,28 @@ impl TryFrom<EventData> for Option<SSE> {
             return Ok(None);
         }
 
-        let event_type = match event_data.event_type.is_empty() {
-            true => String::from("message"),
-            false => event_data.event_type.clone(),
+        let event_type = if event_data.event_type.is_empty() {
+            String::from("message")
+        } else {
+            event_data.event_type
         };
 
         let mut data = event_data.data.clone();
         data.truncate(data.len() - 1);
 
+        let id = if event_data.id.is_empty() {
+            None
+        } else {
+            Some(event_data.id.clone())
+        };
+
+        let retry = event_data.retry;
+
         Ok(Some(SSE::Event(Event {
             event_type,
             data,
-            id: (!event_data.id.is_empty()).then(|| event_data.id.clone()),
-            retry: event_data.retry,
+            id,
+            retry,
         })))
     }
 }

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -442,7 +442,6 @@ mod tests {
         })
     }
 
-    #[allow(dead_code)]
     fn event_with_id(typ: &str, data: &str, id: &str) -> SSE {
         SSE::Event(Event {
             data: data.to_string(),

--- a/eventsource-client/test-data/persistent-event-id.sse
+++ b/eventsource-client/test-data/persistent-event-id.sse
@@ -1,0 +1,14 @@
+event:one
+id: 1
+data:One
+
+event:two
+data:Two
+
+event:three
+id: 3
+data:Three
+
+event:four
+data:Four
+


### PR DESCRIPTION
This PR causes the parser to ignore event IDs that contain null bytes. 
Additionally, it now persists event IDs into subsequent events that lack IDs.

This resolves two SSE test cases.

While making these changes, I encounter some difficulties since we were attempting to parse utf8 in a bunch of places.
I refactored to do utf8 parsing earlier in the process, which removes downstream parsing. 

Additionally, I simplified the unit tests to work with `&str` rather than `&[u8]` since SSE streams are UTF8.

Finally, I enabled a couple capabilities ('headers' and 'last-event-ids') that are now passing.

