### PR TITLE
Make event_parser::Event public

### DIFF
--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -34,4 +34,5 @@ mod event_parser;
 pub use client::*;
 pub use config::*;
 pub use error::*;
+pub use event_parser::Event;
 pub use event_parser::SSE;


### PR DESCRIPTION
Downstream users wouldn't be able to reference the payload of an `event_parser::SSE::Event` (which is an `event_parser::Event`) because it wasn't exported. 

This makes it very inconvenient to try and handle the `SSE` enum properly.

This PR exports it in `lib.rs`.