### PR TITLE
Propagate explicit empty event ID to ReconnectingRequest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEMP_TEST_OUTPUT=/tmp/contract-test-service.log
-SKIPFLAGS = -skip 'reconnection' -skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
+SKIPFLAGS = -skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
 
 
 build-contract-tests:


### PR DESCRIPTION
**Background**
- When reconnecting to an SSE stream, the `ReconnectingRequest` object passes along a `Last-Event-ID` header if the the server had sent one previously.
- `ReconnectingRequest` only sends the header when the ID isn't an empty string.

The event data objects that `ReconnectingRequest` receives are parsed from the raw data structure that the event_parser uses to keep track of the state. This parsing previously transformed an empty event ID into `None`, and non-empty into `Some(ID)`. 

**The bug**
Before this change, `ReconnectingRequest` only updated its own cache of the last event ID when the last event's ID was `Some(ID)`, as defined above. 

This logic is incorrect. `ReconnectingRequest` should always propagate the last known explicit event ID, which could
in fact be an empty string (corresponding to `None`). Without this fix, `ReconnectingRequest` keeps sending a previous `Some(ID)`.

The change represents the empty-string case as `Some("")` rather than `None`.

1. `Some(non-empty string)` -> Send header
2. `None` or `Some(empty string)` -> Don't send header
