### PR TITLE
Handle redirects with new FollowRedirects state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 TEMP_TEST_OUTPUT=/tmp/contract-test-service.log
-SKIPFLAGS = -skip 'HTTP behavior/client follows 301 redirect' -skip 'HTTP behavior/client follows 307 redirect'
-
 
 build-contract-tests:
 	@cargo build

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -73,7 +73,7 @@ pub struct ClientBuilder {
     last_event_id: Option<String>,
     method: String,
     body: Option<String>,
-    max_redirects: u32,
+    max_redirects: Option<u32>,
 }
 
 impl ClientBuilder {
@@ -94,7 +94,7 @@ impl ClientBuilder {
             read_timeout: None,
             last_event_id: None,
             method: String::from("GET"),
-            max_redirects: DEFAULT_REDIRECT_LIMIT,
+            max_redirects: None,
             body: None,
         })
     }
@@ -145,11 +145,10 @@ impl ClientBuilder {
     }
 
     /// Customize the client's following behavior when served a redirect.
-    /// It is not possible to specify unlimited redirects using `None`;
-    /// this instead informs the client that [`DEFAULT_REDIRECT_LIMIT`] should be used.
-    /// To disable redirect following, pass `Some(0)`.
-    pub fn redirect_limit(mut self, limit: Option<u32>) -> ClientBuilder {
-        self.max_redirects = limit.unwrap_or(DEFAULT_REDIRECT_LIMIT);
+    /// To disable following redirects, pass `0`.
+    /// By default, the limit is [`DEFAULT_REDIRECT_LIMIT`].
+    pub fn redirect_limit(mut self, limit: u32) -> ClientBuilder {
+        self.max_redirects = Some(limit);
         self
     }
 
@@ -174,7 +173,7 @@ impl ClientBuilder {
                 method: self.method,
                 body: self.body,
                 reconnect_opts: self.reconnect_opts,
-                max_redirects: self.max_redirects,
+                max_redirects: self.max_redirects.unwrap_or(DEFAULT_REDIRECT_LIMIT),
             },
             last_event_id: self.last_event_id,
         }
@@ -205,7 +204,7 @@ impl ClientBuilder {
                 method: self.method,
                 body: self.body,
                 reconnect_opts: self.reconnect_opts,
-                max_redirects: self.max_redirects,
+                max_redirects: self.max_redirects.unwrap_or(DEFAULT_REDIRECT_LIMIT),
             },
             last_event_id: self.last_event_id,
         }

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -7,8 +7,8 @@ pub enum Error {
     StreamClosed,
     /// An invalid request parameter
     InvalidParameter(Box<dyn std::error::Error + Send + 'static>),
-    /// The HTTP request failed.
-    HttpRequest(StatusCode),
+    /// The HTTP response could not be handled.
+    UnexpectedResponse(StatusCode),
     /// An error reading from the HTTP response body.
     HttpStream(Box<dyn std::error::Error + Send + 'static>),
     /// The HTTP response stream ended
@@ -19,6 +19,10 @@ pub enum Error {
     /// Encountered a line not conforming to the SSE protocol.
     InvalidLine(String),
     InvalidEvent,
+    /// Encountered a malformed Location header.
+    MalformedLocationHeader(Box<dyn std::error::Error + Send + 'static>),
+    /// Reached maximum redirect limit after encountering Location headers.
+    MaxRedirectLimitReached(u32),
     /// An unexpected failure occurred.
     Unexpected(Box<dyn std::error::Error + Send + 'static>),
 }


### PR DESCRIPTION
This PR finishes off the last of the skipped contract tests, which was the 301 & 307 redirect handling.

It adds a new `FollowRedirects` state, which allows the client to follow the `Location` header sent by the server up to a maximum limit. 

Users can configure the limit using `ClientBuilder::redirect_limit`, but they cannot remove it entirely.

I've also added some new SSE tests to verify a couple edge cases (like missing Location header), which I'll put up for review on that repo.

https://github.com/launchdarkly/sse-contract-tests/pull/17