### PR TITLE
Fix usage of split_inclusive in event parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,14 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust:latest
-
+      - image: cimg/rust:1.59.0
     steps:
       - checkout
-
       - run:
-          name: Install clippy
-          command: rustup component add clippy
-      - run:
-          name: Install rustfmt
-          command: rustup component add rustfmt
-
+          name: Check Version
+          command: |
+            cargo --version
+            rustc --version
       - run:
           name: Check consistent formatting
           command: cargo fmt && git diff --exit-code

--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -27,6 +27,8 @@ maplit = "1.0.1"
 simplelog = "0.5.3"
 tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread"] }
 test-case = "1.2.3"
+proptest = "1.0.0"
+
 
 [features]
 default = ["rustls"]

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -281,7 +281,6 @@ impl EventParser {
     // incomplete lines from previous chunks.
     fn decode_and_buffer_lines(&mut self, chunk: Bytes) {
         let mut lines = chunk.split_inclusive(|&b| b == b'\n' || b == b'\r');
-
         // The first and last elements in this split are special. The spec requires lines to be
         // terminated. But lines may span chunks, so:
         //  * the last line, if non-empty (i.e. if chunk didn't end with a line terminator),
@@ -289,10 +288,8 @@ impl EventParser {
         //  * the first line should be appended to the incomplete line, if any
 
         if let Some(incomplete_line) = self.incomplete_line.as_mut() {
-            let line = lines
-                .next()
-                // split always returns at least one item
-                .unwrap();
+            let line = lines.next().expect("Should not be none!");
+            // split always returns at least one item
             trace!(
                 "extending line from previous chunk: {:?}+{:?}",
                 logify(incomplete_line),

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -288,16 +288,14 @@ impl EventParser {
         //  * the first line should be appended to the incomplete line, if any
 
         if let Some(incomplete_line) = self.incomplete_line.as_mut() {
-            let line = lines.next().expect("Should not be none!");
-            // split always returns at least one item
-            trace!(
-                "extending line from previous chunk: {:?}+{:?}",
-                logify(incomplete_line),
-                logify(line)
-            );
+            if let Some(line) = lines.next() {
+                trace!(
+                    "extending line from previous chunk: {:?}+{:?}",
+                    logify(incomplete_line),
+                    logify(line)
+                );
 
-            self.last_char_was_cr = false;
-            if !line.is_empty() {
+                self.last_char_was_cr = false;
                 // Checking the last character handles lines where the last character is a
                 // terminator, but also where the entire line is a terminator.
                 match line.last().unwrap() {

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -289,11 +289,6 @@ impl EventParser {
 
         if let Some(incomplete_line) = self.incomplete_line.as_mut() {
             if let Some(line) = lines.next() {
-                assert!(
-                    !line.is_empty(),
-                    "split_inclusive should never yield an empty line"
-                );
-
                 trace!(
                     "extending line from previous chunk: {:?}+{:?}",
                     logify(incomplete_line),
@@ -301,22 +296,24 @@ impl EventParser {
                 );
 
                 self.last_char_was_cr = false;
-                // Checking the last character handles lines where the last character is a
-                // terminator, but also where the entire line is a terminator.
-                match line.last().unwrap() {
-                    b'\r' => {
-                        incomplete_line.extend_from_slice(&line[..line.len() - 1]);
-                        let il = self.incomplete_line.take();
-                        self.complete_lines.push_back(il.unwrap());
-                        self.last_char_was_cr = true;
-                    }
-                    b'\n' => {
-                        incomplete_line.extend_from_slice(&line[..line.len() - 1]);
-                        let il = self.incomplete_line.take();
-                        self.complete_lines.push_back(il.unwrap());
-                    }
-                    _ => incomplete_line.extend_from_slice(line),
-                };
+                if !line.is_empty() {
+                    // Checking the last character handles lines where the last character is a
+                    // terminator, but also where the entire line is a terminator.
+                    match line.last().unwrap() {
+                        b'\r' => {
+                            incomplete_line.extend_from_slice(&line[..line.len() - 1]);
+                            let il = self.incomplete_line.take();
+                            self.complete_lines.push_back(il.unwrap());
+                            self.last_char_was_cr = true;
+                        }
+                        b'\n' => {
+                            incomplete_line.extend_from_slice(&line[..line.len() - 1]);
+                            let il = self.incomplete_line.take();
+                            self.complete_lines.push_back(il.unwrap());
+                        }
+                        _ => incomplete_line.extend_from_slice(line),
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
The `test-decode-line-split-across-chunks` unit test failed locally on M1 Mac with a panic due to `unwrap()`. It was not failing in CircleCi.

I then realized our CircleCi config was using the old rust image (`circleci/rust`), so I updated to `cimg/rust`, whereupon the test began failing as it did locally. 

Due to https://github.com/rust-lang/rust/pull/89825, `split_inclusive` now returns `None` when it used to return `Some(empty slice)` in our event parser.

The version of rust in `circleci/rust` is Rust 1.49.0, which is before the issue I linked above.

