### PR TITLE
Add code coverage step in CircleCi configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,16 @@ jobs:
       - run: cargo test --all-features
       - run: cargo doc --no-deps
       - run: cargo clippy --all-features -- -D warnings
-
       - store_artifacts:
           path: target/doc
           destination: doc
+      - run:
+          name: Gather Coverage
+          command: ./coverage.sh --html
+      - store_artifacts:
+          name: Upload Coverage
+          path: target/llvm-cov/html
+          destination: coverage
       - run:
           command: make start-contract-test-service
           background: true

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# We are using an older version of the toolchain for now as there is a bug with
+# coverage generation. See https://github.com/rust-lang/rust/issues/79645
+export RUSTUP_TOOLCHAIN=nightly-2022-01-09
+
+# cargo-llvm-cov requires the nightly compiler to be installed
+rustup toolchain install $RUSTUP_TOOLCHAIN
+rustup component add llvm-tools-preview --toolchain $RUSTUP_TOOLCHAIN
+cargo install cargo-llvm-cov
+
+# generate coverage report to command line by default; otherwise allow
+# CI to pass in '--html' (or other formats).
+
+if [ -n "$1" ]; then
+  cargo llvm-cov --all-features --workspace "$1"
+else
+  cargo llvm-cov --all-features --workspace
+fi


### PR DESCRIPTION
Adds code coverage via `llvm-cov`, similar to the [server-sdk](https://github.com/launchdarkly/rust-server-sdk/blob/master/.circleci/config.yml#L27).