### PR TITLE
Fix comment parsing logic

### DIFF
--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -81,6 +81,7 @@ struct Event {
 async fn status() -> impl Responder {
     web::Json(Status {
         capabilities: vec![
+            "comments".to_string(),
             "headers".to_string(),
             "last-event-id".to_string(),
             "read-timeout".to_string(),


### PR DESCRIPTION
Comments are separate from other SSE events and should be emitted as
soon as they are received.