### PR TITLE
Update to cimg/rust:1.60.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.59.0
+      - image: cimg/rust:1.60.0
     steps:
       - checkout
       - run:

--- a/coverage.sh
+++ b/coverage.sh
@@ -3,13 +3,7 @@
 set -o errexit
 set -o pipefail
 
-# We are using an older version of the toolchain for now as there is a bug with
-# coverage generation. See https://github.com/rust-lang/rust/issues/79645
-export RUSTUP_TOOLCHAIN=nightly-2022-01-09
-
-# cargo-llvm-cov requires the nightly compiler to be installed
-rustup toolchain install $RUSTUP_TOOLCHAIN
-rustup component add llvm-tools-preview --toolchain $RUSTUP_TOOLCHAIN
+rustup component add llvm-tools-preview
 cargo install cargo-llvm-cov
 
 # generate coverage report to command line by default; otherwise allow


### PR DESCRIPTION
Updates CircleCi image to `cimg/rust:1.60.0`. In this release of Rust, code coverage was stabilized, so the coverage generation script can be simplified.

[Current report.](https://output.circle-artifacts.com/output/job/203bd39d-ffba-4598-a69f-a7c7acb14a1a/artifacts/0/coverage/index.html)

[Previous report.](https://output.circle-artifacts.com/output/job/f8475b9f-5b27-4619-8450-141d93aa9a2d/artifacts/0/coverage/index.html
)
