### PR TITLE
Add jitter support to retry behavior

### DIFF
--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }
 hyper-timeout = "0.4.1"
+rand = "0.8.5"
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -318,6 +318,7 @@ impl<C> ReconnectingRequest<C> {
                 reconnect_delay,
                 delay_max,
                 backoff_factor,
+                true,
             )),
             redirect_count: 0,
             current_url: url,


### PR DESCRIPTION
According to our streaming spec, the retry behavior should also include
some form of jitter. This jitter will cause the delay to be AT MOST
halved (e.g. a 30 second delay, post jitter will be in the range of
[15, 30] seconds).