### PR TITLE
FEAT: Return headers of connection start

### DIFF
--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -323,7 +323,7 @@ impl<C> ReconnectingRequest<C> {
             redirect_count: 0,
             current_url: url,
             event_parser: EventParser::new(),
-            last_event_id
+            last_event_id,
         }
     }
 
@@ -399,7 +399,9 @@ where
                         Poll::Ready(Some(Ok(event)))
                     }
                     SSE::Comment(_) => Poll::Ready(Some(Ok(event))),
-                    SSE::ConnectionStart(value) => Poll::Ready(Some(Ok(SSE::ConnectionStart(value)))),
+                    SSE::ConnectionStart(value) => {
+                        Poll::Ready(Some(Ok(SSE::ConnectionStart(value))))
+                    }
                 };
             }
 
@@ -433,7 +435,9 @@ where
                         debug!("HTTP response: {:#?}", resp);
 
                         if resp.status().is_success() {
-                            let reply = Poll::Ready(Some(Ok(SSE::ConnectionStart(Some(resp.headers().to_owned())))));
+                            let reply = Poll::Ready(Some(Ok(SSE::ConnectionStart(
+                                resp.headers().to_owned(),
+                            ))));
                             self.as_mut().project().retry_strategy.reset(Instant::now());
                             self.as_mut().reset_redirects();
                             self.as_mut()

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, convert::TryFrom, str::from_utf8};
 
-use hyper::body::Bytes;
+use hyper::{body::Bytes, HeaderMap, http::HeaderValue};
 use log::{debug, log_enabled, trace};
 use pin_project::pin_project;
 
@@ -34,6 +34,7 @@ impl EventData {
 pub enum SSE {
     Event(Event),
     Comment(String),
+    ConnectionStart(Option<HeaderMap<HeaderValue>>)
 }
 
 impl TryFrom<EventData> for Option<SSE> {

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, convert::TryFrom, str::from_utf8};
 
-use hyper::{body::Bytes, HeaderMap, http::HeaderValue};
+use hyper::{body::Bytes, http::HeaderValue, HeaderMap};
 use log::{debug, log_enabled, trace};
 use pin_project::pin_project;
 
@@ -34,7 +34,7 @@ impl EventData {
 pub enum SSE {
     Event(Event),
     Comment(String),
-    ConnectionStart(Option<HeaderMap<HeaderValue>>)
+    ConnectionStart(HeaderMap<HeaderValue>),
 }
 
 impl TryFrom<EventData> for Option<SSE> {


### PR DESCRIPTION
Hi there,

Noticed there was no way to access the headers from the connection creation so I added that in. 

The use case here is that we connect that our providers adds a session cookie in the headers which we need to extract to update the stream (add/remove subscriptions) 

Best regards,
Dario