### PR TITLE
Add `hypertls` profile and update dependencies

### DIFF
--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -23,11 +23,11 @@ hyper-timeout = "0.4.1"
 rand = "0.8.5"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.10.0"
 maplit = "1.0.1"
-simplelog = "0.5.3"
+simplelog = "0.12.0"
 tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread"] }
-test-case = "1.2.3"
+test-case = "2.2.2"
 proptest = "1.0.0"
 
 

--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 [dependencies]
 futures = "0.3.21"
 hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
-hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { version = "0.23.1", optional = true }
 log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }

--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 futures = "0.3.21"
 hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
 hyper-rustls = { version = "0.23.1", optional = true }
+hyper-tls = { version = "0.5.0", optional = true }
 log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }
@@ -30,10 +31,10 @@ tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread"] }
 test-case = "2.2.2"
 proptest = "1.0.0"
 
-
 [features]
 default = ["rustls"]
 rustls = ["hyper-rustls", "hyper/http2"]
+hypertls = ["hyper-tls", "hyper/http2"]
 
 [[example]]
 name = "tail"

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -10,7 +10,7 @@ use hyper::{
     Body, Request, StatusCode, Uri,
 };
 #[cfg(feature = "rustls")]
-use hyper_rustls::HttpsConnector as RustlsConnector;
+use hyper_rustls::{HttpsConnector as RustlsConnector, HttpsConnectorBuilder};
 use log::{debug, info, trace, warn};
 use pin_project::pin_project;
 use std::{
@@ -187,7 +187,11 @@ impl ClientBuilder {
     #[cfg(feature = "rustls")]
     /// Build with an HTTPS client connector, using the OS root certificate store.
     pub fn build(self) -> impl Client {
-        let conn = HttpsConnector::with_native_roots();
+        let conn = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http1()
+            .build();
         self.build_with_conn(conn)
     }
 


### PR DESCRIPTION
In order to integrate the Launchdarkly Rust SDK into [MaterializeInc/materialize](https://github.com/MaterializeInc/materialize), we have to be able to refer to a version that uses `hyper-tls` instead of `hyper-rustls`. This PR adds a `hypertls` profile that achieves that. 

Once this PR and launchdarkly/rust-server-sdk-evaluation#1 are merged and published, I'll open a similar PR against [launchdarkly/rust-server-sdk](https://github.com/launchdarkly/rust-server-sdk) that exposes the `rustls` and `hypertls` profiles in the actual SDK crate.