### PR TITLE
Make `Error` implement `std::fmt::Display`, `std::error::Error` and `Sync` 

### DIFF
--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -6,11 +6,11 @@ pub enum Error {
     TimedOut,
     StreamClosed,
     /// An invalid request parameter
-    InvalidParameter(Box<dyn std::error::Error + Send + 'static>),
+    InvalidParameter(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response could not be handled.
     UnexpectedResponse(StatusCode),
     /// An error reading from the HTTP response body.
-    HttpStream(Box<dyn std::error::Error + Send + 'static>),
+    HttpStream(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response stream ended
     Eof,
     /// The HTTP response stream ended unexpectedly (e.g. in the
@@ -20,11 +20,11 @@ pub enum Error {
     InvalidLine(String),
     InvalidEvent,
     /// Encountered a malformed Location header.
-    MalformedLocationHeader(Box<dyn std::error::Error + Send + 'static>),
+    MalformedLocationHeader(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// Reached maximum redirect limit after encountering Location headers.
     MaxRedirectLimitReached(u32),
     /// An unexpected failure occurred.
-    Unexpected(Box<dyn std::error::Error + Send + 'static>),
+    Unexpected(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl PartialEq<Error> for Error {
@@ -58,7 +58,7 @@ impl Error {
 
 impl<E> From<E> for Error
 where
-    E: std::error::Error + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
 {
     fn from(e: E) -> Error {
         Error::Unexpected(Box::new(e))

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -23,8 +23,6 @@ pub enum Error {
     MalformedLocationHeader(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// Reached maximum redirect limit after encountering Location headers.
     MaxRedirectLimitReached(u32),
-    /// An unexpected failure occurred.
-    Unexpected(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl std::fmt::Display for Error {
@@ -38,11 +36,10 @@ impl std::fmt::Display for Error {
             HttpStream(err) => write!(f, "http error: {err}"),
             Eof => write!(f, "eof"),
             UnexpectedEof => write!(f, "unexpected eof"),
-            InvalidLine(line) => write!(f, "invalid line {line}"),
+            InvalidLine(line) => write!(f, "invalid line: {line}"),
             InvalidEvent => write!(f, "invalid event"),
             MalformedLocationHeader(err) => write!(f, "malformed header: {err}"),
-            MaxRedirectLimitReached(limit) => write!(f, "maximum rediret limit reached: {limit}"),
-            Unexpected(_) => write!(f, "timed out"),
+            MaxRedirectLimitReached(limit) => write!(f, "maximum redirect limit reached: {limit}"),
         }
     }
 }
@@ -72,7 +69,6 @@ impl Error {
     pub fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::HttpStream(err) => Some(err.as_ref()),
-            Error::Unexpected(err) => Some(err.as_ref()),
             _ => None,
         }
     }

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -27,6 +27,28 @@ pub enum Error {
     Unexpected(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        match self {
+            TimedOut => write!(f, "timed out"),
+            StreamClosed => write!(f, "stream closed"),
+            InvalidParameter(err) => write!(f, "invalid parameter: {err}"),
+            UnexpectedResponse(status_code) => write!(f, "unexpected response: {status_code}"),
+            HttpStream(err) => write!(f, "http error: {err}"),
+            Eof => write!(f, "eof"),
+            UnexpectedEof => write!(f, "unexpected eof"),
+            InvalidLine(line) => write!(f, "invalid line {line}"),
+            InvalidEvent => write!(f, "invalid event"),
+            MalformedLocationHeader(err) => write!(f, "malformed header: {err}"),
+            MaxRedirectLimitReached(limit) => write!(f, "maximum rediret limit reached: {limit}"),
+            Unexpected(_) => write!(f, "timed out"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 impl PartialEq<Error> for Error {
     fn eq(&self, other: &Error) -> bool {
         use Error::*;
@@ -53,15 +75,6 @@ impl Error {
             Error::Unexpected(err) => Some(err.as_ref()),
             _ => None,
         }
-    }
-}
-
-impl<E> From<E> for Error
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    fn from(e: E) -> Error {
-        Error::Unexpected(Box::new(e))
     }
 }
 


### PR DESCRIPTION
This is necessary to make it work with error-wrapping libraries like [anyhow](https://crates.io/crates/anyhow) or [eyre](https://crates.io/crates/eyre). Of course it is also generally a good idea. ;-)

Please check if the error descriptions in the `Display` implementation are to your liking. The `impl<E> From<E> for Error` is unused and conflicts with `Error` implementing `std::error::Error` so I removed it.