### PR TITLE
chore: bump cimg/rust to 1.63.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.60.0
+      - image: cimg/rust:1.63.0
     steps:
       - checkout
       - run:

--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -109,7 +109,7 @@ async fn stream(
         Err(_) => return HttpResponse::InternalServerError().body("Unable to retrieve handles"),
     };
 
-    let stream_resource = match req.url_for("stop_stream", &[counter.to_string()]) {
+    let stream_resource = match req.url_for("stop_stream", [counter.to_string()]) {
         Ok(sr) => sr,
         Err(_) => {
             return HttpResponse::InternalServerError()

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -30,7 +30,7 @@ impl EventData {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SSE {
     Event(Event),
     Comment(String),
@@ -70,7 +70,7 @@ impl TryFrom<EventData> for Option<SSE> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Event {
     pub event_type: String,
     pub data: String,


### PR DESCRIPTION
It looks like `time v0.3.20` has bumped its MSRV to 1.63, therefore we need to update it in CI if we wish to continue using it.