### PR TITLE
Update hyper-rustls to 0.23

### DIFF
--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 [dependencies]
 futures = "0.3.21"
 hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
-hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { version = "0.23.2", features = ["http2"], optional = true }
 log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }
@@ -33,7 +33,7 @@ proptest = "1.0.0"
 
 [features]
 default = ["rustls"]
-rustls = ["hyper-rustls", "hyper/http2"]
+rustls = ["hyper-rustls"]
 
 [[example]]
 name = "tail"

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -187,7 +187,12 @@ impl ClientBuilder {
     #[cfg(feature = "rustls")]
     /// Build with an HTTPS client connector, using the OS root certificate store.
     pub fn build(self) -> impl Client {
-        let conn = HttpsConnector::with_native_roots();
+        let conn = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .build();
         self.build_with_conn(conn)
     }
 


### PR DESCRIPTION
rust-eventsource-client using an older version of `hyper-rustls` causes duplicated libraries (and thus bloat) in my project, which depends on hyper-rustls 0.23 indirectly through other dependencies.