### PR TITLE
deps!: Bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.63.0
+      - image: cimg/rust:1.67.0
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ members = [
   "contract-tests",
   "eventsource-client"
 ]
+
+resolver = "2"

--- a/contract-tests/Cargo.toml
+++ b/contract-tests/Cargo.toml
@@ -9,13 +9,12 @@ futures = { version = "0.3.21" }
 serde = { version = "1.0", features = ["derive"] }
 eventsource-client = { path = "../eventsource-client" }
 serde_json = { version = "1.0.39"}
-actix = { version = "0.12.0"}
-actix-web = { version = "4.0.0-beta.10"}
-reqwest = { version = "0.11.6", default_features = false, features = ["json", "rustls-tls"] }
-env_logger = { version = "0.7.1" }
+actix = { version = "0.13.1"}
+actix-web = { version = "4"}
+reqwest = { version = "0.11.6", default-features = false, features = ["json", "rustls-tls"] }
+env_logger = { version = "0.10.0" }
 hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
 log = "0.4.6"
 
 [[bin]]
 name = "sse-test-api"
-

--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 [dependencies]
 futures = "0.3.21"
 hyper = { version = "0.14.17", features = ["client", "http1", "tcp"] }
-hyper-rustls = { version = "0.22.1", optional = true }
+hyper-rustls = { version = "0.24.1", optional = true }
 log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }
@@ -23,17 +23,17 @@ hyper-timeout = "0.4.1"
 rand = "0.8.5"
 
 [dev-dependencies]
-env_logger = "0.7.1"
+env_logger = "0.10.0"
 maplit = "1.0.1"
-simplelog = "0.5.3"
+simplelog = "0.12.1"
 tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread"] }
-test-case = "1.2.3"
+test-case = "3.2.1"
 proptest = "1.0.0"
 
 
 [features]
 default = ["rustls"]
-rustls = ["hyper-rustls", "hyper/http2"]
+rustls = ["hyper-rustls", "hyper-rustls/http2"]
 
 [[example]]
 name = "tail"

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -120,11 +120,11 @@ fn parse_field(line: &[u8]) -> Result<Option<(&str, &str)>> {
 }
 
 fn parse_key(key: &[u8]) -> Result<&str> {
-    from_utf8(key).map_err(|e| Error::InvalidLine(format!("malformed key: {:?}", e)))
+    from_utf8(key).map_err(|e| Error::InvalidLine(format!("malformed key: {e:?}")))
 }
 
 fn parse_value(value: &[u8]) -> Result<&str> {
-    from_utf8(value).map_err(|e| Error::InvalidLine(format!("malformed value: {:?}", e)))
+    from_utf8(value).map_err(|e| Error::InvalidLine(format!("malformed value: {e:?}")))
 }
 
 #[pin_project]


### PR DESCRIPTION
These version bumps bring our dependencies up to the latest versions.

This is technically a breaking change since we export the `HttpsConnector` from `hyper_rustls`, and the structure of that has changed. We now need to rely on the `HttpsConnectorBuilder`.