### PR TITLE
Remove DS Pipeline from Rust eventsource CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Repository Maintainers
-* @launchdarkly/team-decision-science-pipeline @launchdarkly/team-sdk-rust
+* @launchdarkly/team-sdk-rust


### PR DESCRIPTION
I don't think DS Pipeline needs to review changes to this Rust library (which AFAIK is only used in the Rust SDK).