### PR TITLE
feat: return a wrapper on Response on UnexpectedResponse

### DIFF
--- a/contract-tests/src/bin/sse-test-api/main.rs
+++ b/contract-tests/src/bin/sse-test-api/main.rs
@@ -50,14 +50,25 @@ struct Config {
 #[derive(Serialize, Debug)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 enum EventType {
-    Event { event: Event },
-    Comment { comment: String },
-    Error { error: String },
+    Connected {
+        status: u16,
+        headers: HashMap<String, String>,
+    },
+    Event {
+        event: Event,
+    },
+    Comment {
+        comment: String,
+    },
+    Error {
+        error: String,
+    },
 }
 
 impl From<es::SSE> for EventType {
     fn from(event: es::SSE) -> Self {
         match event {
+            es::SSE::Connected((status, headers)) => Self::Connected { status, headers },
             es::SSE::Event(evt) => Self::Event {
                 event: Event {
                     event_type: evt.event_type,

--- a/eventsource-client/examples/tail.rs
+++ b/eventsource-client/examples/tail.rs
@@ -40,6 +40,9 @@ fn tail_events(client: impl es::Client) -> impl Stream<Item = Result<(), ()>> {
     client
         .stream()
         .map_ok(|event| match event {
+            es::SSE::Connected((status, _)) => {
+                println!("got connected: \nstatus={}", status)
+            }
             es::SSE::Event(ev) => {
                 println!("got an event: {}\n{}", ev.event_type, ev.data)
             }

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -27,8 +27,8 @@ use tokio::{
     time::Sleep,
 };
 
-use crate::config::ReconnectOptions;
 use crate::error::{Error, Result};
+use crate::{config::ReconnectOptions, ResponseWrapper};
 
 use hyper::client::HttpConnector;
 use hyper_timeout::TimeoutConnector;
@@ -467,7 +467,10 @@ where
 
                         self.as_mut().reset_redirects();
                         self.as_mut().project().state.set(State::New);
-                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp))));
+
+                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(
+                            ResponseWrapper::new(resp),
+                        ))));
                     }
                     Err(e) => {
                         // This seems basically impossible. AFAIK we can only get this way if we

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -467,7 +467,7 @@ where
 
                         self.as_mut().reset_redirects();
                         self.as_mut().project().state.set(State::New);
-                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp.status()))));
+                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp))));
                     }
                     Err(e) => {
                         // This seems basically impossible. AFAIK we can only get this way if we

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -8,8 +8,8 @@ impl ResponseWrapper {
     pub fn new(response: Response<Body>) -> Self {
         Self { response }
     }
-    pub fn status(&self) -> hyper::http::StatusCode {
-        self.response.status()
+    pub fn status(&self) -> u16 {
+        self.response.status().as_u16()
     }
 
     pub async fn body_bytes(self) -> Result<Vec<u8>> {

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -11,6 +11,9 @@ impl ResponseWrapper {
     pub fn status(&self) -> u16 {
         self.response.status().as_u16()
     }
+    pub fn headers(&self) -> &hyper::header::HeaderMap {
+        self.response.headers()
+    }
 
     pub async fn body_bytes(self) -> Result<Vec<u8>> {
         let body = self.response.into_body();

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -1,4 +1,4 @@
-use hyper::StatusCode;
+use hyper::{Body, Response};
 
 /// Error type returned from this library's functions.
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub enum Error {
     /// An invalid request parameter
     InvalidParameter(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response could not be handled.
-    UnexpectedResponse(StatusCode),
+    UnexpectedResponse(Response<Body>),
     /// An error reading from the HTTP response body.
     HttpStream(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response stream ended
@@ -32,7 +32,10 @@ impl std::fmt::Display for Error {
             TimedOut => write!(f, "timed out"),
             StreamClosed => write!(f, "stream closed"),
             InvalidParameter(err) => write!(f, "invalid parameter: {err}"),
-            UnexpectedResponse(status_code) => write!(f, "unexpected response: {status_code}"),
+            UnexpectedResponse(resp) => {
+                let status = resp.status();
+                write!(f, "unexpected response: {status}")
+            }
             HttpStream(err) => write!(f, "http error: {err}"),
             Eof => write!(f, "eof"),
             UnexpectedEof => write!(f, "unexpected eof"),

--- a/eventsource-client/src/event_parser.rs
+++ b/eventsource-client/src/event_parser.rs
@@ -1,4 +1,8 @@
-use std::{collections::VecDeque, convert::TryFrom, str::from_utf8};
+use std::{
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+    str::from_utf8,
+};
 
 use hyper::body::Bytes;
 use log::{debug, log_enabled, trace};
@@ -32,6 +36,7 @@ impl EventData {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum SSE {
+    Connected((u16, HashMap<String, String>)),
     Event(Event),
     Comment(String),
 }

--- a/eventsource-client/src/lib.rs
+++ b/eventsource-client/src/lib.rs
@@ -14,7 +14,8 @@
 //! let mut stream = Box::pin(client.stream())
 //!     .map_ok(|event| match event {
 //!         SSE::Comment(comment) => println!("got a comment event: {:?}", comment),
-//!         SSE::Event(evt) => println!("got an event: {}", evt.event_type)
+//!         SSE::Event(evt) => println!("got an event: {}", evt.event_type),
+//!         SSE::Connected(_) => println!("got connected")
 //!     })
 //!     .map_err(|e| println!("error streaming events: {:?}", e));
 //! # while let Ok(Some(_)) = stream.try_next().await {}


### PR DESCRIPTION
Fixes #75 

To give access to body bytes to let the user parse the response body for API errors when status code is not 200.

Package it as a wrapper to prevent interference across hyper versions
