### PR TITLE
Enh/expose headers response wrapper

### DIFF
--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -27,8 +27,8 @@ use tokio::{
     time::Sleep,
 };
 
-use crate::config::ReconnectOptions;
 use crate::error::{Error, Result};
+use crate::{config::ReconnectOptions, ResponseWrapper};
 
 use hyper::client::HttpConnector;
 use hyper_timeout::TimeoutConnector;
@@ -467,7 +467,10 @@ where
 
                         self.as_mut().reset_redirects();
                         self.as_mut().project().state.set(State::New);
-                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp))));
+
+                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(
+                            ResponseWrapper::new(resp),
+                        ))));
                     }
                     Err(e) => {
                         // This seems basically impossible. AFAIK we can only get this way if we

--- a/eventsource-client/src/client.rs
+++ b/eventsource-client/src/client.rs
@@ -467,7 +467,7 @@ where
 
                         self.as_mut().reset_redirects();
                         self.as_mut().project().state.set(State::New);
-                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp.status()))));
+                        return Poll::Ready(Some(Err(Error::UnexpectedResponse(resp))));
                     }
                     Err(e) => {
                         // This seems basically impossible. AFAIK we can only get this way if we

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -8,8 +8,8 @@ impl ResponseWrapper {
     pub fn new(response: Response<Body>) -> Self {
         Self { response }
     }
-    pub fn status(&self) -> hyper::http::StatusCode {
-        self.response.status()
+    pub fn status(&self) -> u16 {
+        self.response.status().as_u16()
     }
 
     pub async fn body_bytes(self) -> Result<Vec<u8>> {

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -11,6 +11,9 @@ impl ResponseWrapper {
     pub fn status(&self) -> u16 {
         self.response.status().as_u16()
     }
+    pub fn headers(&self) -> &hyper::header::HeaderMap {
+        self.response.headers()
+    }
 
     pub async fn body_bytes(self) -> Result<Vec<u8>> {
         let body = self.response.into_body();

--- a/eventsource-client/src/error.rs
+++ b/eventsource-client/src/error.rs
@@ -1,4 +1,4 @@
-use hyper::StatusCode;
+use hyper::{Body, Response};
 
 /// Error type returned from this library's functions.
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub enum Error {
     /// An invalid request parameter
     InvalidParameter(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response could not be handled.
-    UnexpectedResponse(StatusCode),
+    UnexpectedResponse(Response<Body>),
     /// An error reading from the HTTP response body.
     HttpStream(Box<dyn std::error::Error + Send + Sync + 'static>),
     /// The HTTP response stream ended
@@ -32,7 +32,10 @@ impl std::fmt::Display for Error {
             TimedOut => write!(f, "timed out"),
             StreamClosed => write!(f, "stream closed"),
             InvalidParameter(err) => write!(f, "invalid parameter: {err}"),
-            UnexpectedResponse(status_code) => write!(f, "unexpected response: {status_code}"),
+            UnexpectedResponse(resp) => {
+                let status = resp.status();
+                write!(f, "unexpected response: {status}")
+            }
             HttpStream(err) => write!(f, "http error: {err}"),
             Eof => write!(f, "eof"),
             UnexpectedEof => write!(f, "unexpected eof"),


### PR DESCRIPTION
The headers are useful to get information such as the `request_id`.