### PR TITLE
fix(deps): bump rand from 0.8.5 to 0.10.1

### DIFF
--- a/eventsource-client/Cargo.toml
+++ b/eventsource-client/Cargo.toml
@@ -17,7 +17,7 @@ http = "1.0"
 log = "0.4.6"
 pin-project = "1.0.10"
 tokio = { version = "1.17.0", features = ["time"] }
-rand = "0.8.5"
+rand = "0.10.1"
 base64 = "0.22.1"
 
 launchdarkly-sdk-transport = { version = "0.1.0" }

--- a/eventsource-client/src/retry.rs
+++ b/eventsource-client/src/retry.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use rand::{thread_rng, Rng};
+use rand::RngExt;
 
 pub(crate) trait RetryStrategy {
     /// Return the next amount of time a failed request should delay before re-attempting.
@@ -59,7 +59,7 @@ impl RetryStrategy for BackoffRetry {
         self.next_delay = std::cmp::min(self.max_delay, current_delay * self.backoff_factor);
 
         if self.include_jitter {
-            thread_rng().gen_range(current_delay / 2..=current_delay)
+            rand::rng().random_range(current_delay / 2..=current_delay)
         } else {
             current_delay
         }


### PR DESCRIPTION
## Summary

Bumps the `rand` dependency from 0.8.5 to 0.10.1 to address a customer-reported security concern with the older version.

The only usage of `rand` is in `retry.rs` for jitter calculation during backoff. The rand 0.10 API changes required updating:
- `thread_rng()` → `rand::rng()`
- `gen_range()` (via `Rng` trait) → `random_range()` (via `RngExt` trait)

The range semantics (`current_delay / 2..=current_delay`) are unchanged.

## Review & Testing Checklist for Human

- [ ] Verify the `rand::RngExt` trait import and `rand::rng().random_range(...)` call are idiomatic for rand 0.10
- [ ] Confirm the updated dependency resolves the specific security concern from the [reported issue](https://github.com/launchdarkly/rust-eventsource-client/issues)
- [ ] Check CI passes — all 59 unit tests passed locally

### Notes

This is a major version bump (0.8 → 0.10), but the API surface used by this crate is minimal (single call site), so the migration is straightforward.

Link to Devin session: https://app.devin.ai/sessions/6f753c80cc4d4afabef3354af1b1eeb6
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a dependency bump with a single call-site update for jitter generation; behavior should remain the same aside from potential RNG implementation differences.
> 
> **Overview**
> Updates the `rand` dependency from `0.8.5` to `0.10.1`.
> 
> Adjusts retry backoff jitter generation in `retry.rs` to the new rand API by switching to `RngExt` and replacing `thread_rng().gen_range(...)` with `rand::rng().random_range(...)` while keeping the jitter range semantics unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cb839d31d802a4f81a669eb8b39c0e1418b242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->